### PR TITLE
Use RunwayType enum values in is_runway helper

### DIFF
--- a/xplane_airports/AptDat.py
+++ b/xplane_airports/AptDat.py
@@ -18,6 +18,8 @@ class RunwayType(Enum):
     WATER_RUNWAY = 101
     HELIPAD = 102
 
+    def __int__(self):
+        return self.value
 
 class AptDatLine:
     """
@@ -37,7 +39,7 @@ class AptDatLine:
         :returns: True if this line represents a land runway, waterway, or helipad
         :rtype: bool
         """
-        return self.row_code in [100, 101, 102]
+        return self.row_code in [int(RunwayType.LAND_RUNWAY), int(RunwayType.WATER_RUNWAY), int(RunwayType.HELIPAD)]
 
     def is_ignorable(self):
         """


### PR DESCRIPTION
I'm not sure if this improves things or not, so feel free to scrap it if it's not. I was looking for a way to avoid repeated codes since they are already defined in the enum. It turned out this required a few extra lines of code and explicit int cast, so I'm not totally sure it's the best option (nonetheless, I think it would be nice to avoid repetition - it's always error prone).

If you think it's OK and worth it, I can try to apply similiar pattern to other - currently hardcoded - numbers, exposing them via enums first.